### PR TITLE
Add tests for item usage, building upgrades, and effect expiration

### DIFF
--- a/test/models/active_effect_test.rb
+++ b/test/models/active_effect_test.rb
@@ -20,4 +20,13 @@ class ActiveEffectTest < ActiveSupport::TestCase
     @active_effect.update(expires_at: 1.hour.ago)
     assert_not_includes ActiveEffect.active, @active_effect
   end
+
+  test "active scope returns only non-expired effects" do
+    active = active_effects(:one)
+    expired = active_effects(:two)
+    active.update(expires_at: 1.hour.from_now)
+    expired.update(expires_at: 1.hour.ago)
+
+    assert_equal [active], ActiveEffect.active.to_a
+  end
 end

--- a/test/services/building_service_test.rb
+++ b/test/services/building_service_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BuildingServiceTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:one)
+    @service = BuildingService.new(@user)
+  end
+
+  test "create_building adds building to user" do
+    building = buildings(:two)
+    assert_nil @user.user_buildings.find_by(building: building)
+
+    result = @service.create_building(building.id)
+
+    assert result[:success]
+    assert_not_nil @user.user_buildings.find_by(building: building)
+  end
+
+  test "upgrade_building increases level" do
+    user_building = user_buildings(:one)
+
+    result = @service.upgrade_building(user_building.id)
+
+    assert result[:success]
+    assert_equal 2, user_building.reload.level
+  end
+end

--- a/test/services/item_service_test.rb
+++ b/test/services/item_service_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ItemServiceTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:one)
+  end
+
+  test "use calls increase_luck effect" do
+    item = items(:one)
+    service = ItemService.new(@user, item)
+    service.expects(:increase_luck)
+    service.use
+  end
+
+  test "use calls reset_cooldown effect" do
+    item = items(:two)
+    service = ItemService.new(@user, item)
+    service.expects(:reset_cooldown)
+    service.use
+  end
+end


### PR DESCRIPTION
## Summary
- Add ItemService tests to ensure item effects trigger
- Cover building creation and upgrading in BuildingService tests
- Verify ActiveEffect scope filters out expired effects

## Testing
- ⚠️ `bundle install` (403 "Forbidden" while fetching gems)
- ⚠️ `bundle exec rails test` (bundler could not find `rails` executable)
- ⚠️ `bundle exec rubocop` (bundler could not find `rubocop` executable)


------
https://chatgpt.com/codex/tasks/task_e_689e1c7ef8408325894543bfda4de9c5