### PR TITLE
Fix array bracket spacing in ActiveEffectTest

### DIFF
--- a/test/models/active_effect_test.rb
+++ b/test/models/active_effect_test.rb
@@ -27,6 +27,6 @@ class ActiveEffectTest < ActiveSupport::TestCase
     active.update(expires_at: 1.hour.from_now)
     expired.update(expires_at: 1.hour.ago)
 
-    assert_equal [active], ActiveEffect.active.to_a
+    assert_equal [ active ], ActiveEffect.active.to_a
   end
 end


### PR DESCRIPTION
## Summary
- fix Rubocop Layout/SpaceInsideArrayLiteralBrackets in ActiveEffectTest

## Testing
- `bundle exec rubocop`
- `bundle exec rails test` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e21d68d548325b6047732f1b733ae