### PR TITLE
Add importmap configuration and audit script

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,2 @@
+import "@hotwired/turbo-rails"
+import "controllers"

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,7 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+application.debug = false
+window.Stimulus = application
+
+export { application }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+import { application } from "./application"
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+
+eagerLoadControllersFrom("controllers", application)

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require_relative "../config/boot"
+require "importmap-rails"
+require "importmap/commands"
+Importmap::Commands.start

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,7 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application", preload: true
+pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
+pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
## Summary
- Add basic importmap configuration and Stimulus controllers setup
- Provide `bin/importmap` helper script for managing JavaScript pins

## Testing
- `bin/importmap audit`
- `bin/rails test` *(fails: cannot load debug/prelude due to missing gem)*

------
https://chatgpt.com/codex/tasks/task_e_689e21f408ec8325b7616a0221e9a5b5